### PR TITLE
Renamed arguments named this with self to avoid g++ compile problems

### DIFF
--- a/inc/adt_stack.h
+++ b/inc/adt_stack.h
@@ -24,20 +24,20 @@ typedef struct adt_stack_tag{
 /***************** Public Function Declarations *******************/
 //Constructor/Destructor
 adt_stack_t*	adt_stack_new(void (*pDestructor)(void*));
-void 			adt_stack_delete(adt_stack_t *this);
-void 	adt_stack_create(adt_stack_t *this, void (*pDestructor)(void*));
-void 	adt_stack_destroy(adt_stack_t *this);
-void 	adt_stack_clear(adt_stack_t *this);
+void 			adt_stack_delete(adt_stack_t *self);
+void 	adt_stack_create(adt_stack_t *self, void (*pDestructor)(void*));
+void 	adt_stack_destroy(adt_stack_t *self);
+void 	adt_stack_clear(adt_stack_t *self);
 
 
 //Accessors
-void	adt_stack_push(adt_stack_t *this, void *pVal);
-void*	adt_stack_top(adt_stack_t *this);
-void*	adt_stack_pop(adt_stack_t *this);
+void	adt_stack_push(adt_stack_t *self, void *pVal);
+void*	adt_stack_top(adt_stack_t *self);
+void*	adt_stack_pop(adt_stack_t *self);
 
 //Utility functions
-void	adt_stack_reserve(adt_stack_t *this,uint32_t u32Len);
-void	adt_stack_resize(adt_stack_t *this,uint32_t u32Len);
-uint32_t adt_stack_size(adt_stack_t *this);
+void	adt_stack_reserve(adt_stack_t *self,uint32_t u32Len);
+void	adt_stack_resize(adt_stack_t *self,uint32_t u32Len);
+uint32_t adt_stack_size(adt_stack_t *self);
 
 #endif //ADT_STACK_H__

--- a/inc/adt_str.h
+++ b/inc/adt_str.h
@@ -31,21 +31,21 @@ adt_str_t *adt_str_new(void);
 
 /**
  * deletes an adt_str object
- * \param[in]	this	object instance
+ * \param[in]	self	object instance
  */
-void adt_str_delete(adt_str_t *this);
+void adt_str_delete(adt_str_t *self);
 
 /**
  * constructor
- * \param[in]	this	object instance
+ * \param[in]	self	object instance
  */
-void adt_str_create(adt_str_t *this);
+void adt_str_create(adt_str_t *self);
 
 /**
  * destructor
- * \param[in]	this	object instance
+ * \param[in]	self	object instance
  */
-void adt_str_destroy(adt_str_t *this);
+void adt_str_destroy(adt_str_t *self);
 
 
 /* adt_str functions */
@@ -56,23 +56,23 @@ void adt_str_destroy(adt_str_t *this);
  */
 adt_str_t *adt_str_dup(adt_str_t* other);
 adt_str_t *adt_str_make(const char *pBegin, const char *pEnd);
-int32_t adt_str_length(adt_str_t *this);
-void adt_str_clear(adt_str_t *this);
+int32_t adt_str_length(adt_str_t *self);
+void adt_str_clear(adt_str_t *self);
 void adt_str_set(adt_str_t *lhs, adt_str_t *rhs);
 void adt_str_append(adt_str_t *lhs,adt_str_t *rhs);
-void adt_str_reserve(adt_str_t *this,int32_t s32Len);
-void adt_str_push(adt_str_t *this,const int c);
-int adt_str_pop(adt_str_t *this);
-int adt_str_get_char(adt_str_t *this,int index);
+void adt_str_reserve(adt_str_t *self,int32_t s32Len);
+void adt_str_push(adt_str_t *self,const int c);
+int adt_str_pop(adt_str_t *self);
+int adt_str_get_char(adt_str_t *self,int index);
 
 /* C string compatible functions */
 adt_str_t *adt_str_dup_cstr(const char* cstr); //constructor
-void adt_str_set_cstr(adt_str_t *this, const char *cstr);
-void adt_str_append_cstr(adt_str_t *this,const char *cstr);
-void adt_str_prepend_cstr(adt_str_t *this,const char *cstr);
-void adt_str_copy_range(adt_str_t *this,const char *pBegin,const char *pEnd);
-void adt_str_append_range(adt_str_t *this,const char *pBegin,const char *pEnd);
-const char* adt_str_cstr(adt_str_t *this);
+void adt_str_set_cstr(adt_str_t *self, const char *cstr);
+void adt_str_append_cstr(adt_str_t *self,const char *cstr);
+void adt_str_prepend_cstr(adt_str_t *self,const char *cstr);
+void adt_str_copy_range(adt_str_t *self,const char *pBegin,const char *pEnd);
+void adt_str_append_range(adt_str_t *self,const char *pBegin,const char *pEnd);
+const char* adt_str_cstr(adt_str_t *self);
 
 
 

--- a/src/adt_stack.c
+++ b/src/adt_stack.c
@@ -29,130 +29,130 @@
 
 //Constructor/Destructor
 adt_stack_t* adt_stack_new(void (*pDestructor)(void*)){
-	adt_stack_t *this;
-	if((this = (adt_stack_t*) malloc(sizeof(adt_stack_t))) == 0){
+	adt_stack_t *self;
+	if((self = (adt_stack_t*) malloc(sizeof(adt_stack_t))) == 0){
 		return (adt_stack_t*)0;
 	}
-	adt_stack_create(this,pDestructor);
-	return this;
+	adt_stack_create(self,pDestructor);
+	return self;
 }
 
-void adt_stack_delete(adt_stack_t *this){
-	if(this){
-		adt_stack_destroy(this);
-		free(this);
+void adt_stack_delete(adt_stack_t *self){
+	if(self){
+		adt_stack_destroy(self);
+		free(self);
 	}
 }
 
-void adt_stack_create(adt_stack_t *this, void (*pDestructor)(void*)){
-	this->ppAlloc = (void**) 0;
-	this->u32AllocLen = 0;
-	this->u32CurLen = 0;
-	this->u32MinLen = ADT_STACK_DEFAULT_MIN_LEN;
-	this->pDestructor = pDestructor;
+void adt_stack_create(adt_stack_t *self, void (*pDestructor)(void*)){
+	self->ppAlloc = (void**) 0;
+	self->u32AllocLen = 0;
+	self->u32CurLen = 0;
+	self->u32MinLen = ADT_STACK_DEFAULT_MIN_LEN;
+	self->pDestructor = pDestructor;
 }
 
-void adt_stack_destroy(adt_stack_t *this){
+void adt_stack_destroy(adt_stack_t *self){
 	uint32_t u32i;
 
-	void **ppElem=this->ppAlloc;
-	if(this->pDestructor){
-		for(u32i=0;u32i<this->u32CurLen;u32i++){
-			this->pDestructor(*(ppElem++));
+	void **ppElem=self->ppAlloc;
+	if(self->pDestructor){
+		for(u32i=0;u32i<self->u32CurLen;u32i++){
+			self->pDestructor(*(ppElem++));
 		}
 	}
-	if(this->ppAlloc != 0){
-		free(this->ppAlloc);
+	if(self->ppAlloc != 0){
+		free(self->ppAlloc);
 	}
-	this->ppAlloc = (void**) 0;
-	this->u32AllocLen = 0;
-	this->u32CurLen = 0;
+	self->ppAlloc = (void**) 0;
+	self->u32AllocLen = 0;
+	self->u32CurLen = 0;
 }
 
-void adt_stack_clear(adt_stack_t *this){
-	adt_stack_destroy(this);
+void adt_stack_clear(adt_stack_t *self){
+	adt_stack_destroy(self);
 }
 
 
 //Accessors
-void	adt_stack_push(adt_stack_t *this, void *pVal){
-	if(!this) return;
-	if(this->u32CurLen==this->u32AllocLen){
-		if(this->u32AllocLen==0){
-			adt_stack_resize(this,this->u32MinLen);
+void	adt_stack_push(adt_stack_t *self, void *pVal){
+	if(!self) return;
+	if(self->u32CurLen==self->u32AllocLen){
+		if(self->u32AllocLen==0){
+			adt_stack_resize(self,self->u32MinLen);
 		}
 		else{
 			//default growth by doubling items available
-			adt_stack_resize(this,this->u32AllocLen*2);
+			adt_stack_resize(self,self->u32AllocLen*2);
 		}
 	}
-	assert(this->u32CurLen<this->u32AllocLen);
-	assert(this->ppAlloc != 0);
-	this->ppAlloc[this->u32CurLen++] = pVal;
+	assert(self->u32CurLen<self->u32AllocLen);
+	assert(self->ppAlloc != 0);
+	self->ppAlloc[self->u32CurLen++] = pVal;
 }
-void* adt_stack_top(adt_stack_t *this){
-	if(this && (this->u32CurLen>0)){
-		assert(this->ppAlloc);
-		return this->ppAlloc[this->u32CurLen-1];
+void* adt_stack_top(adt_stack_t *self){
+	if(self && (self->u32CurLen>0)){
+		assert(self->ppAlloc);
+		return self->ppAlloc[self->u32CurLen-1];
 	}
 	return (void*)0;
 }
 
-void* adt_stack_pop(adt_stack_t *this){
-	if(this && (this->u32CurLen>0)){
-		assert(this->ppAlloc);
-		return this->ppAlloc[--this->u32CurLen];
+void* adt_stack_pop(adt_stack_t *self){
+	if(self && (self->u32CurLen>0)){
+		assert(self->ppAlloc);
+		return self->ppAlloc[--self->u32CurLen];
 	}
 	return (void*)0;
 }
 
 //Utility functions
-void adt_stack_reserve(adt_stack_t *this,uint32_t u32Len){
-	if(this){
-		this->u32MinLen = u32Len;
-		if(this->u32AllocLen < this->u32MinLen){
-			adt_stack_resize(this,this->u32MinLen);
+void adt_stack_reserve(adt_stack_t *self,uint32_t u32Len){
+	if(self){
+		self->u32MinLen = u32Len;
+		if(self->u32AllocLen < self->u32MinLen){
+			adt_stack_resize(self,self->u32MinLen);
 		}
 	}
 }
 
-void adt_stack_resize(adt_stack_t *this,uint32_t u32Len){
+void adt_stack_resize(adt_stack_t *self,uint32_t u32Len){
 	void **ppAlloc = (void**) 0;
-	if(!this) return;
-	if(u32Len == this->u32AllocLen) return; //nothing to do
+	if(!self) return;
+	if(u32Len == self->u32AllocLen) return; //nothing to do
 
-	assert(this->u32AllocLen>=this->u32CurLen);
+	assert(self->u32AllocLen>=self->u32CurLen);
 	if(u32Len>0){
 		ppAlloc = (void**) malloc(u32Len * sizeof(void*));
 		assert(ppAlloc != 0);
 	}
-	if(this->ppAlloc){
-		if(u32Len > this->u32AllocLen){
+	if(self->ppAlloc){
+		if(u32Len > self->u32AllocLen){
 			//grow
-			memcpy(ppAlloc,this->ppAlloc,this->u32AllocLen * sizeof(void*));
+			memcpy(ppAlloc,self->ppAlloc,self->u32AllocLen * sizeof(void*));
 		}
 		else{
 			//shrink
-			if( this->u32CurLen > u32Len){
+			if( self->u32CurLen > u32Len){
 				//call destructor on superfluous elements
-				if(this->pDestructor){
+				if(self->pDestructor){
 					uint32_t u32i;
-					for(u32i=u32Len; u32i < this->u32CurLen;u32i++){
-						this->pDestructor(this->ppAlloc[u32i]);
+					for(u32i=u32Len; u32i < self->u32CurLen;u32i++){
+						self->pDestructor(self->ppAlloc[u32i]);
 					}
 				}
 			}
-			memcpy(ppAlloc,this->ppAlloc,u32Len * sizeof(void*));
+			memcpy(ppAlloc,self->ppAlloc,u32Len * sizeof(void*));
 		}
-		free(this->ppAlloc);
+		free(self->ppAlloc);
 	}
-	this->ppAlloc = ppAlloc;
-	this->u32AllocLen = u32Len;
+	self->ppAlloc = ppAlloc;
+	self->u32AllocLen = u32Len;
 
 }
-uint32_t adt_stack_size(adt_stack_t *this){
-	if(this){
-		return this->u32CurLen;
+uint32_t adt_stack_size(adt_stack_t *self){
+	if(self){
+		return self->u32CurLen;
 	}
 	return 0;
 }

--- a/src/adt_str.c
+++ b/src/adt_str.c
@@ -20,7 +20,7 @@
 
 /*
  * Each string starts out being 16 bytes in length
- * When this becomes too small, it quadruples in size (multiply by 4) until it reaches 64K.
+ * When self becomes too small, it quadruples in size (multiply by 4) until it reaches 64K.
  * It then doubles until it reaches 64MB. After that it does linear growth in chunks of 64MB.
  */
 #define MIN_BLOCK_SIZE 		16
@@ -37,35 +37,35 @@ static int32_t adt_str_calcLen(int32_t s32CurLen, int32_t u32NewLen);
 /****************** Public Function Definitions *******************/
 /* constructor/destructor */
 adt_str_t *adt_str_new(void){
-	adt_str_t *this;
-	if((this = (adt_str_t*) malloc(sizeof(adt_str_t))) == 0){
+	adt_str_t *self;
+	if((self = (adt_str_t*) malloc(sizeof(adt_str_t))) == 0){
 		return (adt_str_t*)0;
 	}
-	adt_str_create(this);
-	return this;
+	adt_str_create(self);
+	return self;
 }
 
 
-void adt_str_delete(adt_str_t *this){
-	if(this){
-		adt_str_destroy(this);
-		free(this);
+void adt_str_delete(adt_str_t *self){
+	if(self){
+		adt_str_destroy(self);
+		free(self);
 	}
 }
 
-void adt_str_create(adt_str_t *this){
-	if(this){
-		this->s32Cur = 0;
-		this->s32Len = 0;
-		this->pStr = (uint8_t*)0;
+void adt_str_create(adt_str_t *self){
+	if(self){
+		self->s32Cur = 0;
+		self->s32Len = 0;
+		self->pStr = (uint8_t*)0;
 	}
 }
-void adt_str_destroy(adt_str_t *this){
-	if(this){
-		if(this->pStr) free(this->pStr);
-		this->pStr=0;
-		this->s32Cur = 0;
-		this->s32Len = 0;
+void adt_str_destroy(adt_str_t *self){
+	if(self){
+		if(self->pStr) free(self->pStr);
+		self->pStr=0;
+		self->s32Cur = 0;
+		self->s32Len = 0;
 	}
 }
 
@@ -73,33 +73,33 @@ void adt_str_destroy(adt_str_t *this){
 /* adt_str functions */
 
 adt_str_t *adt_str_dup(adt_str_t* other){
-	adt_str_t *this;
-	this = adt_str_new();
-	if(this){
-		adt_str_set(this,other);
+	adt_str_t *self;
+	self = adt_str_new();
+	if(self){
+		adt_str_set(self,other);
 	}
-	return this;
+	return self;
 }
 
 adt_str_t *adt_str_make(const char *pBegin, const char *pEnd){
-	adt_str_t *this;
-	this = adt_str_new();
-	if(this){
-		adt_str_copy_range(this,pBegin,pEnd);
+	adt_str_t *self;
+	self = adt_str_new();
+	if(self){
+		adt_str_copy_range(self,pBegin,pEnd);
 	}
-	return this;
+	return self;
 }
 
-int32_t adt_str_length(adt_str_t *this){
-	if(this){
-		return this->s32Cur;
+int32_t adt_str_length(adt_str_t *self){
+	if(self){
+		return self->s32Cur;
 	}
 	return 0;
 }
 
-void adt_str_clear(adt_str_t *this){
-	if(this == 0) return;
-	this->s32Cur = 0;
+void adt_str_clear(adt_str_t *self){
+	if(self == 0) return;
+	self->s32Cur = 0;
 }
 
 void adt_str_set(adt_str_t *lhs, adt_str_t *rhs){
@@ -114,49 +114,49 @@ void adt_str_set(adt_str_t *lhs, adt_str_t *rhs){
 
 void adt_str_append(adt_str_t *lhs,adt_str_t *rhs);
 
-void adt_str_reserve(adt_str_t *this,int32_t s32Len){
+void adt_str_reserve(adt_str_t *self,int32_t s32Len){
    uint8_t *pStr;
    s32Len++; //reserve 1 byte for null terminator
-	if(s32Len <= this->s32Len){
+	if(s32Len <= self->s32Len){
 		return;
 	}
-	this->s32Len = adt_str_calcLen(this->s32Len,s32Len);
-   pStr = (uint8_t*) malloc(this->s32Len);
+	self->s32Len = adt_str_calcLen(self->s32Len,s32Len);
+   pStr = (uint8_t*) malloc(self->s32Len);
 	assert(pStr);
-	if(this->pStr){
-		memcpy(pStr,this->pStr,this->s32Cur);
-		free(this->pStr);
+	if(self->pStr){
+		memcpy(pStr,self->pStr,self->s32Cur);
+		free(self->pStr);
 	}
-	this->pStr = pStr;
+	self->pStr = pStr;
 }
 
-void adt_str_push(adt_str_t *this,const int c){
-	if(this == 0) return;
-	assert(this->s32Cur<(INT_MAX-2));
-	adt_str_reserve(this,this->s32Cur+1);
-	assert(this->s32Cur < this->s32Len);
-	this->pStr[this->s32Cur++] = (uint8_t) c;
-	assert(this->s32Cur < this->s32Len);
+void adt_str_push(adt_str_t *self,const int c){
+	if(self == 0) return;
+	assert(self->s32Cur<(INT_MAX-2));
+	adt_str_reserve(self,self->s32Cur+1);
+	assert(self->s32Cur < self->s32Len);
+	self->pStr[self->s32Cur++] = (uint8_t) c;
+	assert(self->s32Cur < self->s32Len);
 }
 
-int adt_str_pop(adt_str_t *this){
+int adt_str_pop(adt_str_t *self){
 	int retval = 0;
-	if(this){
-		if(this->s32Cur>0){
-			retval = this->pStr[--this->s32Cur];
-			this->pStr[this->s32Cur] = 0;
+	if(self){
+		if(self->s32Cur>0){
+			retval = self->pStr[--self->s32Cur];
+			self->pStr[self->s32Cur] = 0;
 		}
 	}
 	return retval;
 }
 
-int adt_str_get_char(adt_str_t *this,int index){
-	if(this){
+int adt_str_get_char(adt_str_t *self,int index){
+	if(self){
 		int32_t s32Index;
 		if(index<0){
 			s32Index=(int32_t) (-index);
-			if(s32Index<=this->s32Cur){
-				s32Index=this->s32Cur-s32Index;
+			if(s32Index<=self->s32Cur){
+				s32Index=self->s32Cur-s32Index;
 			}
 			else{
 				return -1; //out of bounds error
@@ -164,11 +164,11 @@ int adt_str_get_char(adt_str_t *this,int index){
 		}
 		else{
 			s32Index = (int32_t) index;
-			if(s32Index>=this->s32Cur){
+			if(s32Index>=self->s32Cur){
 				return -1; //out of bounds error
 			}
 		}
-		return (int) this->pStr[s32Index];
+		return (int) self->pStr[s32Index];
 	}
 	return -1;
 }
@@ -177,71 +177,71 @@ int adt_str_get_char(adt_str_t *this,int index){
 /* C string compatible functions */
 adt_str_t *adt_str_dup_cstr(const char* cstr){
 	if(cstr){
-		adt_str_t *this = adt_str_new();
-		if(this==0) return this;
-		adt_str_set_cstr(this,cstr);
-		return this;
+		adt_str_t *self = adt_str_new();
+		if(self==0) return self;
+		adt_str_set_cstr(self,cstr);
+		return self;
 	}
 	return (adt_str_t*) 0;
 }
 
 
 
-void adt_str_set_cstr(adt_str_t *this, const char *str){
+void adt_str_set_cstr(adt_str_t *self, const char *str){
 	int32_t s32Len = (uint32_t) strlen(str);
-	adt_str_reserve(this,s32Len);
-	assert(this->s32Len>s32Len);
-	assert(this->pStr);
-	memcpy(this->pStr,str,s32Len);
-	this->s32Cur=s32Len;
+	adt_str_reserve(self,s32Len);
+	assert(self->s32Len>s32Len);
+	assert(self->pStr);
+	memcpy(self->pStr,str,s32Len);
+	self->s32Cur=s32Len;
 }
 
-void adt_str_append_cstr(adt_str_t *this,const char *str){
+void adt_str_append_cstr(adt_str_t *self,const char *str){
 	int32_t s32Len = (int32_t) strlen(str);
-	adt_str_reserve(this,this->s32Cur+s32Len);
-	assert(this->s32Len>this->s32Cur+s32Len);
-	memcpy(this->pStr+this->s32Cur,str,s32Len);
-	this->s32Cur+=s32Len;
-	this->pStr[this->s32Cur] = 0;
+	adt_str_reserve(self,self->s32Cur+s32Len);
+	assert(self->s32Len>self->s32Cur+s32Len);
+	memcpy(self->pStr+self->s32Cur,str,s32Len);
+	self->s32Cur+=s32Len;
+	self->pStr[self->s32Cur] = 0;
 }
 
-void adt_str_prepend_cstr(adt_str_t *this,const char *cstr);
+void adt_str_prepend_cstr(adt_str_t *self,const char *cstr);
 
 
-void adt_str_copy_range(adt_str_t *this,const char *pBegin,const char *pEnd){
+void adt_str_copy_range(adt_str_t *self,const char *pBegin,const char *pEnd){
    int32_t s32Len;
-   if( (this == 0) || (pBegin == 0) || (pEnd == 0)) return;
+   if( (self == 0) || (pBegin == 0) || (pEnd == 0)) return;
 	if(pBegin>=pEnd) return;
    s32Len = (int32_t) (pEnd-pBegin);
-	adt_str_reserve(this,s32Len);
-	assert(this->s32Len>s32Len);
-	assert(this->pStr);
-	memcpy(this->pStr,pBegin,s32Len);
-	this->s32Cur = s32Len;
+	adt_str_reserve(self,s32Len);
+	assert(self->s32Len>s32Len);
+	assert(self->pStr);
+	memcpy(self->pStr,pBegin,s32Len);
+	self->s32Cur = s32Len;
 }
 
-void adt_str_append_range(adt_str_t *this,const char *pBegin,const char *pEnd){
+void adt_str_append_range(adt_str_t *self,const char *pBegin,const char *pEnd){
    int32_t s32Len;
    int32_t s32NewLen;
-   if ((this == 0) || (pBegin == 0) || (pEnd == 0)) return;
+   if ((self == 0) || (pBegin == 0) || (pEnd == 0)) return;
 	if(pBegin>=pEnd) return;
    s32Len = (int32_t) (pEnd-pBegin);
-   s32NewLen = this->s32Len + s32Len;
-	adt_str_reserve(this,s32NewLen);
-	assert(this->s32Len>s32NewLen);
-	assert(this->pStr);
-	memcpy(this->pStr+this->s32Len,pBegin,s32Len);
-	this->s32Cur = s32NewLen;
+   s32NewLen = self->s32Len + s32Len;
+	adt_str_reserve(self,s32NewLen);
+	assert(self->s32Len>s32NewLen);
+	assert(self->pStr);
+	memcpy(self->pStr+self->s32Len,pBegin,s32Len);
+	self->s32Cur = s32NewLen;
 }
 
-const char* adt_str_cstr(adt_str_t *this){
-	if(this){
-		if(!this->pStr){
-			adt_str_reserve(this,0);
+const char* adt_str_cstr(adt_str_t *self){
+	if(self){
+		if(!self->pStr){
+			adt_str_reserve(self,0);
 		}
-		assert(this->s32Cur<this->s32Len);
-		this->pStr[this->s32Cur]=0;
-		return (const char*) this->pStr;
+		assert(self->s32Cur<self->s32Len);
+		self->pStr[self->s32Cur]=0;
+		return (const char*) self->pStr;
 	}
 	return 0;
 }


### PR DESCRIPTION
Renamed arguments named "this" to "self" since "this" is a protected keyword in g++. 