### PR TITLE
Bugfix/msvc issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 **/Debug/
 **/Release/
 **/UnitTest/
+/VisualStudio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ if(ADT_RBFH_ENABLE)
     message(STATUS "ADT_RBFH_ENABLE=1")
     target_compile_definitions(adt PUBLIC ADT_RBFH_ENABLE=1)
 endif()
+
+if(MSVC)
+    target_compile_definitions(adt PUBLIC _CRT_SECURE_NO_WARNINGS)
+endif()
+
 ###
 
 ###Executable adt_unit

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ $ cmake --build .
 $ ./adt_unit
 ```
 
+An alternative way of achieving the same result is to manually activate both UNIT_TEST and LEAK_CHECK.
+
+```bash
+$ mkdir Debug && cd Debug
+$ cmake -DUNIT_TEST=ON -DLEAK_CHECK=ON ..
+$ cmake --build .
+$ ./adt_unit
+```
+
 ### Running unit tests (Windows + Visual Studio)
 
 From the Windows start menu launch a Visual Studio command prompt.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ unit tests for adt_hash. These takes several seconds to run so they are not enab
 |-----------------------|------------------------------|-------------------------------------------------|
 | ADT_TEST_ADT_HASH_FULL| -DADT_TEST_ADT_HASH_FULL=ON  | Enables additional (slow) tests for adt_hash_t    |
 
+Note that above flag has no effect when building with Visual Studio (due to
+lack of support for the *getline* function). A custom implementation for
+Visual Studio might be implemented at a later time.
+
 #### ADT Ringbuffer
 
 By default, adt_ringbuf.c will not compile anything unless you explicitly enable it using CMake options.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ If you are looking for higher level data types in C you can check out the [cogu/
 
 ## Building with CMake
 
-CMake files exist but has so far only been tested on Linux.
+CMake build have been tested on Linux and Windows.
+Building on Windows works but there is room for improvement in the CMake file (adding folders etc. for Visual Studio)
 
-### Running unit tests (Linux)
+### Running unit tests (Linux + GCC)
 
 ```bash
 $ mkdir UnitTest && cd UnitTest
@@ -52,6 +53,21 @@ $ cmake -DCMAKE_BUILD_TYPE=UnitTest ..
 $ cmake --build .
 $ ./adt_unit
 ```
+
+### Running unit tests (Windows + Visual Studio)
+
+From the Windows start menu launch a Visual Studio command prompt.
+
+For example, I use Visual Studio 2019 which mean I launch the "x64 Native Tools Command Prompt for VS2019". It conveniently has CMake for windows pre-installed and it generates Visual Studio projects without the need of giving extra options to CMake.
+
+```cmd
+$ mkdir VisualStudio && cd VisualStudio
+$ cmake -DUNIT_TEST=ON -DLEAK_CHECK=ON ..
+$ cmake --build . --config Debug
+$ Debug\adt_unit.exe
+```
+
+
 ### ADT CMake Options
 
 CMake options can be set from command line or using a CMake GUI tool (such as ccmake for Linux).

--- a/src/adt_bytearray.c
+++ b/src/adt_bytearray.c
@@ -192,7 +192,7 @@ adt_error_t adt_bytearray_trimLeft(adt_bytearray_t *self, const uint8_t *pSrc){
        *       start = self->u32CurLen
        *       remain = 0
        */
-      start = pSrc - self->pData;
+      start = (uint32_t) (pSrc - self->pData);
       remain = self->u32CurLen - start;
       if(pSrc == self->pData){
          //no action

--- a/src/adt_hash.c
+++ b/src/adt_hash.c
@@ -296,8 +296,8 @@ void adt_hnode_destroy(adt_hnode_t *node,void (*pDestructor)(void*)){
 		free(node->child.match);
 	}
 	else{
-      uint8_t i; 
-      assert(node->u8Width==16);		
+      uint8_t i;
+      assert(node->u8Width==16);
 		for(i=0;i<16;i++){
 			adt_hnode_destroy(&node->child.node[i],pDestructor);
 		}
@@ -311,7 +311,7 @@ void adt_hnode_destroy_shallow(adt_hnode_t *node){
 	}
 	else{
       uint8_t i;
-		assert(node->u8Width==16);		
+		assert(node->u8Width==16);
 		for(i=0;i<16;i++){
 			adt_hnode_destroy_shallow(&node->child.node[i]);
 		}

--- a/test/CMemLeak.c
+++ b/test/CMemLeak.c
@@ -450,7 +450,7 @@ void  XWBReportFinal (void)
 char* XWBStrDup (const char* iOrig, const char* iFile, const unsigned int iLine)
 {
     char* result;
-    result = XWBMalloc (strlen (iOrig) + 1, iFile, iLine);
+    result = XWBMalloc ( ((unsigned int) strlen (iOrig)) + 1u, iFile, iLine);
     strcpy (result, iOrig);
     return result;
 }

--- a/test/adt/testsuite_adt_ary.c
+++ b/test/adt/testsuite_adt_ary.c
@@ -41,6 +41,11 @@ void vfree(void* p);
 #define vfree free
 #endif
 
+#ifdef _MSC_VER
+#define STRDUP _strdup
+#else
+#define STRDUP strdup
+#endif
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -121,10 +126,10 @@ static void test_adt_ary_push_pop(CuTest* tc)
 	char *pVal;
 	adt_ary_t *pArray = adt_ary_new(vfree);
 	CuAssertPtrNotNull(tc, pArray);
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,strdup("The")));
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,strdup("quick")));
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,strdup("brown")));
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,strdup("fox")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,STRDUP("The")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,STRDUP("quick")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,STRDUP("brown")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_push(pArray,STRDUP("fox")));
 	CuAssertPtrNotNull(tc,pArray->ppAlloc);
 	CuAssertPtrEquals(tc, vfree,pArray->pDestructor);
 	CuAssertIntEquals(tc,4,pArray->s32AllocLen);
@@ -159,28 +164,28 @@ static void test_adt_ary_unshift(CuTest* tc)
 	CuAssertIntEquals(tc,0,adt_ary_length(pArray));
 	CuAssertPtrEquals(tc, vfree,pArray->pDestructor);
 
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=strdup("The")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=STRDUP("The")));
 	CuAssertIntEquals(tc,1,adt_ary_length(pArray));
 	CuAssertPtrNotNull(tc, (ppVal = adt_ary_get(pArray,0)));
 	pVal = (char*) *ppVal;
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "The",pVal);
 
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=strdup("quick")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=STRDUP("quick")));
 	CuAssertIntEquals(tc,2,adt_ary_length(pArray));
 	CuAssertPtrNotNull(tc, (ppVal = adt_ary_get(pArray,0)));
 	pVal = (char*) *ppVal;
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "quick",pVal);
 
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=strdup("brown")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=STRDUP("brown")));
 	CuAssertIntEquals(tc,3,adt_ary_length(pArray));
 	CuAssertPtrNotNull(tc, (ppVal = adt_ary_get(pArray,0)));
 	pVal = (char*) *ppVal;
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "brown",pVal);
 
-	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=strdup("fox")));
+	CuAssertIntEquals(tc, ADT_NO_ERROR, adt_ary_unshift(pArray,tmp=STRDUP("fox")));
 	CuAssertIntEquals(tc,4,adt_ary_length(pArray));
 	CuAssertPtrNotNull(tc, (ppVal = adt_ary_get(pArray,0)));
 	pVal = (char*) *ppVal;

--- a/test/adt/testsuite_adt_hash.c
+++ b/test/adt/testsuite_adt_hash.c
@@ -64,7 +64,7 @@ void test_adt_hash_iterator(CuTest* tc){
 	CuAssertIntEquals(tc,4,adt_hash_length(pHash));
 	adt_hash_delete(pHash);
 }
-
+#ifndef _MSC_VER //MSCV doesn't have the getline function so we disable this test.
 void test_adt_hash_iterator2(CuTest* tc){
 	adt_hash_t *pHash = adt_hash_new(NULL);
 	CuAssertPtrNotNull(tc, pHash);
@@ -125,6 +125,7 @@ void test_adt_hash_iterator2(CuTest* tc){
 	adt_hash_delete(pHash);
 	free(line);
 }
+#endif
 
 void test_adt_hash_keys(CuTest* tc)
 {
@@ -241,7 +242,7 @@ CuSuite* testsuite_adt_hash(void)
 
 	SUITE_ADD_TEST(suite, test_adt_hash_constructor);
 	SUITE_ADD_TEST(suite, test_adt_hash_iterator);
-#if TEST_ADT_HASH_FULL //Note that this test takes several seconds to run, normally disabled
+#if (!defined(_MSC_VER) && defined(TEST_ADT_HASH_FULL)) //Note that this test takes several seconds to run, normally disabled
 	SUITE_ADD_TEST(suite, test_adt_hash_iterator2);
 #endif
 	SUITE_ADD_TEST(suite, test_adt_hash_keys);

--- a/test/adt/testsuite_adt_hash.c
+++ b/test/adt/testsuite_adt_hash.c
@@ -242,7 +242,7 @@ CuSuite* testsuite_adt_hash(void)
 
 	SUITE_ADD_TEST(suite, test_adt_hash_constructor);
 	SUITE_ADD_TEST(suite, test_adt_hash_iterator);
-#if (!defined(_MSC_VER) && defined(TEST_ADT_HASH_FULL)) //Note that this test takes several seconds to run, normally disabled
+#if (!defined(_MSC_VER) && defined(TEST_ADT_HASH_FULL) && (TEST_ADT_HASH_FULL != 0) ) //Note that this test takes several seconds to run, normally disabled
 	SUITE_ADD_TEST(suite, test_adt_hash_iterator2);
 #endif
 	SUITE_ADD_TEST(suite, test_adt_hash_keys);

--- a/test/adt/testsuite_adt_list.c
+++ b/test/adt/testsuite_adt_list.c
@@ -8,6 +8,12 @@
 #include "CMemLeak.h"
 #endif
 
+#ifdef _MSC_VER
+#define STRDUP _strdup
+#else
+#define STRDUP strdup
+#endif
+
 /**************** Private Function Declarations *******************/
 static void test_adt_list_new(CuTest* tc);
 static void test_adt_list_insert_remove(CuTest* tc);
@@ -48,8 +54,8 @@ static void test_adt_list_insert_remove(CuTest* tc)
 {
    adt_list_t *list;
    list = adt_list_new(NULL);
-   char *hello=strdup("hello");
-   char *world=strdup("world");
+   char *hello=STRDUP("hello");
+   char *world=STRDUP("world");
    CuAssertPtrNotNull(tc,list);
    adt_list_insert(list, hello);
    adt_list_insert(list, world);
@@ -69,8 +75,8 @@ static void test_adt_list_insert_unique(CuTest* tc)
 {
    adt_list_t *list;
    list = adt_list_new(vfree);
-   char *hello=strdup("hello");
-   char *world=strdup("world");
+   char *hello=STRDUP("hello");
+   char *world=STRDUP("world");
    CuAssertPtrNotNull(tc,list);
    adt_list_insert_unique(list, hello);
    adt_list_insert_unique(list, world);
@@ -87,8 +93,8 @@ static void test_adt_list_insert_erase(CuTest* tc)
    adt_list_t *list;
    adt_list_elem_t *iter;
    list = adt_list_new(NULL);
-   char *hello=strdup("hello");
-   char *world=strdup("world");
+   char *hello=STRDUP("hello");
+   char *world=STRDUP("world");
    CuAssertPtrNotNull(tc,list);
    adt_list_insert(list, hello);
    adt_list_insert(list, world);
@@ -113,9 +119,9 @@ static void test_adt_list_clear(CuTest* tc)
 {
    adt_list_t *list;
    list = adt_list_new(vfree);
-   char *hello=strdup("hello");
-   char *world=strdup("world");
-   char *foo=strdup("foo");
+   char *hello=STRDUP("hello");
+   char *world=STRDUP("world");
+   char *foo=STRDUP("foo");
    CuAssertPtrNotNull(tc,list);
    adt_list_insert(list, hello);
    adt_list_insert(list, world);

--- a/test/adt/testsuite_adt_stack.c
+++ b/test/adt/testsuite_adt_stack.c
@@ -12,6 +12,12 @@ void vfree(void* p);
 #define vfree free
 #endif
 
+#ifdef _MSC_VER
+#define STRDUP _strdup
+#else
+#define STRDUP strdup
+#endif
+
 void test_adt_stack_new(CuTest* tc)
 {
 	adt_stack_t *pStack = adt_stack_new(NULL);
@@ -27,10 +33,10 @@ void test_adt_stack_push(CuTest* tc)
 {
 	adt_stack_t *pStack = adt_stack_new(vfree);
 	CuAssertPtrNotNull(tc, pStack);
-	adt_stack_push(pStack,strdup("The"));
-	adt_stack_push(pStack,strdup("quick"));
-	adt_stack_push(pStack,strdup("brown"));
-	adt_stack_push(pStack,strdup("fox"));
+	adt_stack_push(pStack,STRDUP("The"));
+	adt_stack_push(pStack,STRDUP("quick"));
+	adt_stack_push(pStack,STRDUP("brown"));
+	adt_stack_push(pStack,STRDUP("fox"));
 	CuAssertPtrNotNull(tc,pStack->ppAlloc);
 	CuAssertPtrEquals(tc, vfree,pStack->pDestructor);
 	CuAssertIntEquals(tc,8,pStack->u32AllocLen);
@@ -48,28 +54,28 @@ void test_adt_stack_top(CuTest* tc)
 	CuAssertPtrEquals(tc, 0,adt_stack_top(pStack));
 
 
-	adt_stack_push(pStack,strdup("The"));
+	adt_stack_push(pStack,STRDUP("The"));
 	CuAssertIntEquals(tc,1,adt_stack_size(pStack));
 	pVal = (char*) adt_stack_top(pStack);
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "The",pVal);
 	free(pVal);
 
-	adt_stack_push(pStack,strdup("quick"));
+	adt_stack_push(pStack,STRDUP("quick"));
 	CuAssertIntEquals(tc,2,adt_stack_size(pStack));
 	pVal = (char*) adt_stack_top(pStack);
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "quick",pVal);
 	free(pVal);
 
-	adt_stack_push(pStack,strdup("brown"));
+	adt_stack_push(pStack,STRDUP("brown"));
 	CuAssertIntEquals(tc,3,adt_stack_size(pStack));
 	pVal = (char*) adt_stack_top(pStack);
 	CuAssertPtrNotNull(tc, pVal);
 	CuAssertStrEquals(tc, "brown",pVal);
 	free(pVal);
 
-	adt_stack_push(pStack,strdup("fox"));
+	adt_stack_push(pStack,STRDUP("fox"));
 	CuAssertIntEquals(tc,4,adt_stack_size(pStack));
 	pVal = (char*) adt_stack_top(pStack);
 	CuAssertPtrNotNull(tc, pVal);
@@ -88,15 +94,15 @@ void test_adt_stack_pop(CuTest* tc)
 	CuAssertIntEquals(tc,0,adt_stack_size(pStack));
 	CuAssertPtrEquals(tc, 0,adt_stack_top(pStack));
 
-	adt_stack_push(pStack,strdup("The"));
+	adt_stack_push(pStack,STRDUP("The"));
 	CuAssertIntEquals(tc,1,adt_stack_size(pStack));
-	adt_stack_push(pStack,strdup("quick"));
+	adt_stack_push(pStack,STRDUP("quick"));
 	CuAssertIntEquals(tc,2,adt_stack_size(pStack));
 
-	adt_stack_push(pStack,strdup("brown"));
+	adt_stack_push(pStack,STRDUP("brown"));
 	CuAssertIntEquals(tc,3,adt_stack_size(pStack));
 
-	adt_stack_push(pStack,strdup("fox"));
+	adt_stack_push(pStack,STRDUP("fox"));
 	CuAssertIntEquals(tc,4,adt_stack_size(pStack));
 
 	pVal = (char*) adt_stack_pop(pStack);

--- a/test/adt/testsuite_adt_str.c
+++ b/test/adt/testsuite_adt_str.c
@@ -456,8 +456,8 @@ static void test_adt_str_push(CuTest* tc){
 	for(i = 'A'; i <= 'Z'; i++){
 		len++;
 		adt_str_push(str,i);
-		CuAssertIntEquals(tc,len,strlen(adt_str_cstr(str)));
-		CuAssertIntEquals(tc,len,adt_str_length(str));
+		CuAssertIntEquals(tc, len, (int) strlen(adt_str_cstr(str)));
+		CuAssertIntEquals(tc, len, adt_str_length(str));
 	}
 
 	CuAssertStrEquals(tc,"ABCDEFGHIJKLMNOPQRSTUVWXYZ",adt_str_cstr(str));
@@ -476,9 +476,9 @@ static void test_adt_str_pop(CuTest* tc){
 		len--;
 		c = (char) adt_str_pop(str);
 		CuAssertTrue(tc,len>=0);
-		CuAssertIntEquals(tc,len,strlen(adt_str_cstr(str)));
-		CuAssertIntEquals(tc,len,adt_str_length(str));
-		CuAssertIntEquals(tc,i,c);
+		CuAssertIntEquals(tc, len, (int) strlen(adt_str_cstr(str)));
+		CuAssertIntEquals(tc, len, adt_str_length(str));
+		CuAssertIntEquals(tc, i, c);
 	}
 	CuAssertTrue(tc,len==0);
 	CuAssertStrEquals(tc,"",adt_str_cstr(str));
@@ -733,9 +733,9 @@ static void test_adt_adding_nulls_at_end_shall_not_be_part_of_length(CuTest* tc)
    adt_str_t *str = adt_str_new();
    CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_set_bstr(str, test1, test1+sizeof(test1)));
    CuAssertIntEquals(tc, 3, adt_str_length(str));
-   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_set_bstr(str, test2, test1+sizeof(test2)));
+   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_set_bstr(str, test2, test2+sizeof(test2)));
    CuAssertIntEquals(tc, 0, adt_str_length(str));
-   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_set_bstr(str, test3, test1+sizeof(test3)));
+   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_set_bstr(str, test3, test3+sizeof(test3)));
    CuAssertIntEquals(tc, 1, adt_str_length(str));
    adt_str_delete(str);
 }
@@ -750,10 +750,10 @@ static void test_adt_str_append_bstr_containing_nulls_at_end(CuTest* tc)
    CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_append_bstr(str, test1, test1+sizeof(test1)));
    CuAssertIntEquals(tc, 3, adt_str_length(str));
    adt_str_clear(str);
-   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_append_bstr(str, test2, test1+sizeof(test2)));
+   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_append_bstr(str, test2, test2+sizeof(test2)));
    CuAssertIntEquals(tc, 0, adt_str_length(str));
    adt_str_clear(str);
-   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_append_bstr(str, test3, test1+sizeof(test3)));
+   CuAssertIntEquals(tc, ADT_NO_ERROR, adt_str_append_bstr(str, test3, test3+sizeof(test3)));
    CuAssertIntEquals(tc, 1, adt_str_length(str));
    adt_str_delete(str);
 }


### PR DESCRIPTION
Building ADT using CMake now works on Windows with Visual Studio 2019.

Should probably work fine with older versions of Visual Studio as well (VS 2012 or newer since VS2010 never had the standard header stdbool.h).